### PR TITLE
Fix 3D Model Viewer importing

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
         window.location.href = 'https:' + window.location.href.substring(5);
       }
     </script>
-		<script type="importmap">
-			{
-				"imports": {
-					"three": "https://threejs.org/build/three.module.js",
-                    "objloader": "https://threejs.org/examples/jsm/loaders/OBJLoader.js",
-				}
-			}
-		</script>
+    <script type="importmap">
+        {
+            "imports": {
+                "three": "https://threejs.org/build/three.module.js",
+                "objloader": "https://threejs.org/examples/jsm/loaders/OBJLoader.js"
+            }
+        }
+    </script>
     <!-- import the webpage's stylesheet -->
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/light.css" id="light" class="alternate" disabled>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,14 @@
         window.location.href = 'https:' + window.location.href.substring(5);
       }
     </script>
-
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://threejs.org/build/three.module.js",
+                    "objloader": "https://threejs.org/examples/jsm/loaders/OBJLoader.js",
+				}
+			}
+		</script>
     <!-- import the webpage's stylesheet -->
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/light.css" id="light" class="alternate" disabled>

--- a/js/script.js
+++ b/js/script.js
@@ -8,9 +8,8 @@
 /* global TextDecoderStream */
 'use strict';
 
-import * as THREE from 'https://threejs.org/build/three.module.js';
-import {OrbitControls} from 'https://threejs.org/examples/jsm/controls/OrbitControls.js';
-import {OBJLoader} from 'https://threejs.org/examples/jsm/loaders/OBJLoader.js';
+import * as THREE from 'three';
+import {OBJLoader} from 'objloader';
 
 let port;
 let reader;


### PR DESCRIPTION
Looks like imports are now handled different in the browser. Tested fix on https://makermelissa.github.io/Adafruit_WebSerial_3DModelViewer/.